### PR TITLE
Added link to May First/People Link

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Coop | Business Areas | Region/Country | Notes
 [Kedu](https://kedu.coop/en/home) | Software, infrastructure | Barcelona, Spain |
 [Koumbit](https://www.koumbit.org/en) | Hosting, Websites, Sysadmin | Montreal, Quebec, Canada |
 [Loomio](https://www.loomio.org) | Online decision-making app |  Wellington, New Zealand | [Wikipedia](https://en.wikipedia.org/wiki/Loomio)
-[May First/People Link](https://mayfirst.org/) | Hosting | USA and Mexico |
+[May First Movement Technology](https://mayfirst.coop/) | Hosting | USA and Mexico |
 [MuchDifferent](http://www.muchdifferent.com) | Game technology, Engineering | Uppsala, Sweden |
 [Nilenso](https://nilenso.com) | Development (Clojure, Javascript, Ruby, Haskell, Go, Java) | Bangalore, India |
 [Outlandish](https://outlandish.com/) | Web development | London, UK | Sponsored [2016 Outlandish Fellowships](https://www.outlandish.com/fellowship/) |

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Coop | Business Areas | Region/Country | Notes
 [Jamgo](http://jamgo.coop/en/) | Front-end dev, design services, e-commerce, Drupal/WordPress | Barcelona, Spain |
 [Koumbit](https://www.koumbit.org/en) | Hosting, Websites, Sysadmin | Montreal, Quebec, Canada |
 [Loomio](https://www.loomio.org) | Online decision-making app |  Wellington, New Zealand | [Wikipedia](https://en.wikipedia.org/wiki/Loomio)
+[May First/People Link](https://mayfirst.org/) | Hosting | USA and Mexico |
 [MuchDifferent](http://www.muchdifferent.com) | Game technology, Engineering | Uppsala, Sweden |
 [Nilenso](https://nilenso.com) | Development (Clojure, Javascript, Ruby, Haskell, Go, Java) | Bangalore, India |
 [Outlandish](https://outlandish.com/) | Web development | London, UK | Sponsored [2016 Outlandish Fellowships](https://www.outlandish.com/fellowship/) |


### PR DESCRIPTION
Add a link to [May First/People Link](https://mayfirst.org/) &mdash; I understand that they are a co-operative but this isn't so clear from their web site which mostly emphasises that they are a progressive membership based organisation. Their [membership form](https://outreach.mayfirst.org/joinus) does make it clear that the Mexican organisation is a Coop.

They have [a list of services](https://support.mayfirst.org/wiki/services) on their open Trac site.

