### PR TITLE
Remove Gaia Host

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,6 @@ Coop | Business Areas | Region/Country | Notes
 [Eryx](https://eryx.co) | Full-stack development, Data Science, Operations Research, UX, Consulting | CABA, Buenos Aires, Argentina |
 [Feel Train](https://feeltrain.com/) |  | Portland, OR, USA | *"Feel Train will never consist of more than 8 people."*
 [Fiqus](http://fiqus.com) | Web and mobile development | Buenos Aires, Argentina |
-[Gaia Host Collective](http://gaiahost.coop) | Hosting | Greenfield, MA, USA |
 [gcoop](https://gcoop.coop) | Hosting, Consulting, Web Development, FLOSS Development | Buenos Aires, Argentina |*"Transformamos los sistemas."*
 [GNU Coop](https://www.gnucoop.com/) | Open source development, training, e-learning, project management | Italy |
 [Go free Range](http://gofreerange.com) | Web development | UK |


### PR DESCRIPTION
Gaia Host has shut down as of August 1, 2019 - extended to October 1 for hosting services and November 1 for domain transfers out.

see https://gaiahost.coop/help#status

in case the page goes down, archive.org link:

https://web.archive.org/web/20191217024930/https://gaiahost.coop/help

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hng/tech-coops/40)
<!-- Reviewable:end -->
