### PR TITLE
Adds Camplight coop Medium articles link

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ Coop | Business Areas | Region/Country | Notes
 * [The Case for Technology Worker Coops from a Former Freelancer](https://www.colab.coop/blog/the-case-for-technology-worker-coops-from-a-former-freelancer/)
 * [Post-Capitalist Solutions: How Worker-Owned Tech Co-ops Are Boosting the Solidarity Economy](http://www.occupy.com/article/post-capitalist-solutions-how-worker-owned-tech-co-ops-are-boosting-solidarity-economy#sthash.9q8hqH7v.1klLVNEi.dpbs) (occupy.com)
 * [Incorporating Notes: On Cooperatives, Nonprofits, and Better Accountability](https://colet.space/blog/incorporating-notes/) by the Collective for Liberation, Ecology, and Technology
+* [Tales from a digital cooperative and friends that are evolving human collaboration](https://medium.com/camplight) (by Camplight)
 
 #### Financing / Salaries
 


### PR DESCRIPTION
In addition to the Camplight addition to the coop table, adds a link to our Medium blog posts.