### PR TITLE
Adds Camplight coop Moodlight product link

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,7 @@ Coop | Business Areas | Region/Country | Notes
 * [Cobuy](https://github.com/enspiral-root-systems/cobuy) - Group wholesale purchases as a consumer co-op (by Root Systems).
 * [CoopHub](https://coophub.io) - Git repos from cooperatives around the world!
 * [Up & Go](https://www.upandgo.coop) - Cooperative Home Cleaning Services (by CoLab).
+* [Moodlight](https://assista.io) - Emotional intelligence for teams (by Camplight)
 
 <a name="jobs" />
 


### PR DESCRIPTION
In addition to the Camplight addition to the coop table, adds a link to our Medium blog posts.