### PR TITLE
Add Kaleidos

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Coop | Business Areas | Region/Country | Notes
 [IT Kollektiv](https://it-kollektiv.com) | Cross-platform apps, web development, backend development, consulting | GER | Network-type
 [IT Kollektivet](http://www.it-kollektivet.dk) |  | Copenhagen, Denmark |
 [Jamgo](http://jamgo.coop/en/) | Front-end dev, design services, e-commerce, Drupal/WordPress | Barcelona, Spain |
+[Kaleidos](https://kaleidos.net/) | Front-end, mobile, UX/UI design, open source software | Madrid, Spain |
 [Kedu](https://kedu.coop/en/home) | Software, infrastructure | Barcelona, Spain |
 [Koumbit](https://www.koumbit.org/en) | Hosting, Websites, Sysadmin | Montreal, Quebec, Canada |
 [Loomio](https://www.loomio.org) | Online decision-making app |  Wellington, New Zealand | [Wikipedia](https://en.wikipedia.org/wiki/Loomio)


### PR DESCRIPTION
Although governed like a coop for a long time, since last year Kaleidos became [100% worker owned](https://blog.kaleidos.net/Kaleidos-pasa-a-ser-100-de-socios-empleados/).

\cc @diacritica 