### PR TITLE
Added DEFUNCT.md for keeping a record of past coops

### DIFF
--- a/DEFUNCT.md
+++ b/DEFUNCT.md
@@ -1,0 +1,8 @@
+# Defunct coops list
+This list is maintained for informational purposes. These coops have closed since being listed in the main list.
+
+### North America
+
+Coop | Business Areas | Region/Country | Notes
+---- | -------------- | -------------- | -----
+[Feel Train](https://feeltrain.com/) |  | Portland, OR, USA | *"Feel Train will never consist of more than 8 people."*

--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ Coop | Business Areas | Notes
 
 ### Other lists
 
+ * [Historical / defunct coops](./DEFUNCT.md)
  * [Awesome Tech Cooperatives](https://github.com/mwmeyer/awesome-tech-cooperatives) - A collection of awesome cooperative tech companies and projects
 
  <a name="networks" />


### PR DESCRIPTION
For purposes of the main list being useful, it's nice not to show coops that don't exist. But
for information, we can keep a list of previous coops in a way that is more accessible than git history.

I'm not sure about where I put the link to DEFUNCT.md, so please suggest alternatives if you have an idea.

This PR is in response to some discussion on #100 