### PR TITLE
Add Mellium Co-op chat

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,6 +278,7 @@ Coop | Business Areas | Notes
 ### Chat rooms
 
 * [#cooptech:autonomic.zone](https://matrix.to/#/!eTkOeRURalzRzbBfBK:autonomic.zone?via=autonomic.zone&via=1312.media) (Matrix chat for CoTech)
+* [Cooperative Development](https://mellium.chat/), `co-op@mellium.chat` (XMPP/Jabber compatible)
 
 <a name="tools" />
 


### PR DESCRIPTION
Added a link to the Co-op development room on the Mellium Co-op chat server. This room is for general co-op and co-operative economy discussion and is not Mellium Co-op specific.