### PR TITLE
Add Yaal coop company and Canaille project to tech-coops

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ Coop | Business Areas | Region/Country | Notes
 [UNI:CODE IT Solutions](https://unicode-it.de) | Web development, IT services | Germany, Remote | |
 [Webarchitects Co-operative](https://www.webarchitects.coop) | Hosting, Sysadmin | Sheffield, UK | Multi-stakeholder, including workers, organisations and investors |
 [WTF Kooperative eG](https://wtf-eg.de/) | Software Development, Hosting, Consulting, less bureaucracy for freelancers in germany  | Germany, Remote | eG legal German Coop, founded 2020 |
+[Yaal Coop](https://yaal.coop)| Web development, open source development, technical investment | Bordeaux (France) | Worker-owned cooperative focused on social impact startups. |
 
 <a name="coops-oceania" />
 
@@ -298,6 +299,7 @@ Coop | Business Areas | Notes
 ## Software/Products created by tech coops
 
 * [API Platform](https://api-platform.com/) - REST and GraphQL framework on top of Symfony and React.
+* [Canaille](https://pypi.org/project/Canaille/) - Simple account manager and an OpenID Connect provider based upon a LDAP database.
 * [Cobuy](https://github.com/enspiral-root-systems/cobuy) - Group wholesale purchases as a consumer co-op (by Root Systems).
 * [CoopHub](https://coophub.io) - Git repos from cooperatives around the world!
 * [Up & Go](https://www.upandgo.coop) - Cooperative Home Cleaning Services (by CoLab).


### PR DESCRIPTION
Hi hng, hi tech-coops,

Heard about your repo, so here is my request to add our coop (and an open source product we develop) in the list.
Yaal is a 10 years old conventional company. Last year, we, a team of 5 people, **made a "fork" to create our own coop**: [Yaal Coop](https://yaal.coop/). In France, it is specifically a **SCIC**, a collective interest cooperative company, basically the same as a french **SCOP** but we can also chose to associate clients, suppliers, other cooperatives that we want to make them participate in our decision making.

Thank you!
And great project by the way.