### PR TITLE
Adding Gemify to North American Tech Coops

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Coop | Business Areas | Region/Country | Notes
 [Electric Embers](https://electricembers.coop) | Hosting | San Francisco, CA, USA | |
 [FullSteam Labs](https://www.fullsteamlabs.com) | Web application development, UI & UX Design | USA | 
 [Future Club](https://www.futureclub.dev/) | Game development | USA | |
+[Gemify](https://gemify.tech) | Software Development, UX Research and Design | San Jose, California, USA | Worker-owned tech co-operative developing affordable solutions for small businesses since 2019. Preparing to launch an accessibility-focused restaurant menu builder [Mealtree](https://mealtr.ee/). |
 [Hypha Worker Co-operative](https://hypha.coop/) | Digital coaching, (decentralized) web design, and development | Tkaronto (Toronto), Ontario, Canada | Founded in 2019 with the mission to help organizations and communities redesign their relationships with digital technology. |
 [Informal Systems](https://informal.systems) | Distribute Systems and Formal Verification |  Tkaronto (Toronto), Ontario, Canada | Working towards an open-source ecosystem of cooperatively owned and governed distributed organizations running on reliable distributed systems 
 [Interstitial Technology](https://interstitial.coop) | Full-stack engineering - design, development, firmware, electrical engineering  | USA/Canada | Focused on technology with positive social impact


### PR DESCRIPTION
Hoping to add out worker coop, Gemify, to the list. Website should prove that we are indeed a worker coop.

### Potential Issue With Listing
- *One* pull request for every new link

Included Mealtree application in description as it is the app that we are currently building out. Feel free to reject or edit if this does not meet this criteria listed in contributions.