### PR TITLE
Add The Drivers Cooperative

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Coop | Business Areas | Region/Country | Notes
 [Politics Rewired](https://politicsrewired.com/) | Political campaigning and organizing tools | USA
 [Position Development](https://positiondev.com/) | Software Development | Brooklyn, NY | Focused on independent media, cultural institutions, and socially minded organizations
 [Sassafras Tech Collective](http://sassafras.coop/) | Research, User experience design, Development | Ann Arbor, Michigan, USA | |
+[The Drivers Cooperative](https://drivers.coop) | Driver-owned rideshare | New York City, NY, USA | Drivers own 100% of the company. Developing an entirely new platform.
 [The Glory Society](http://theglorysociety.com/) | Games | US | Founded in 2019
 [the Tech Support Cooperative](https://site.techsupport.coop/) | POS software, open-source web development, consulting | US + CAN | Maintainers of the [CORE-POS / IS4C](https://github.com/CORE-POS/IS4C) software project |
 [Tierra Común](https://tierracomun.org/) | digital security, sysadmin, web design | Mexico | |


### PR DESCRIPTION
From https://drivers.coop/about:

> We are a driver-owned ridehailing cooperative in New York City. Drivers make more on each trip, all profits go back to drivers, and drivers have democratic control over the decisions that affect their lives.
>
> Our mission is to end exploitative conditions in the for-hire vehicle industry through system change– putting drivers in the driver’s seat of the platform economy.
