### PR TITLE
Add Probesys

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ Coop | Business Areas | Region/Country | Notes
 [MuchDifferent](http://www.muchdifferent.com) | Game technology, Engineering | Uppsala, Sweden | |
 [multi](http://www.multi.coop) | Web development, data science, innovation, open source, open data | France | Tech workers owned. Created in 2022 |
 [Outlandish](https://outlandish.com/) | Web development | London, UK | Sponsored [2016 Outlandish Fellowships](https://www.outlandish.com/fellowship/) |
+[Probesys](https://www.probesys.com) | Web development, System Administration, Hosting | Grenoble, France | We provide Open Source development and infrastructure expertise |
 [Rabotnik](https://www.rabotnik.coop/) |  graphic design, web-development, video production and animation, campaign and concept development | Denmark | |
 [Reinblau](https://reinblau.coop/) | Web development | Berlin, Germany | |
 [Resonate](http://resonate.is) | Music Streaming  | Berlin, Germany / Dublin, Ireland| A multistakeholder platform co-operative - with contributors (workers, contractors, volunteers) represented with a 20% ownership stake.


### PR DESCRIPTION
This is a PR to add Probesys cooperative society https://www.probesys.com/
We exist as a SCOP (french for Worker Cooperative Society  of Production) since 2003, we have also created a cooperative group with another society that we have transformed into a SCOP in 2017.
We are referenced in the French SCOP movement: https://www.les-scop.coop/probesys