### PR TITLE
Archive Brierwood Coop

### DIFF
--- a/DEFUNCT.md
+++ b/DEFUNCT.md
@@ -5,6 +5,7 @@ This list is maintained for informational purposes. These coops have closed sinc
 
 Coop | Business Areas | Region/Country | Notes
 ---- | -------------- | -------------- | -----
+[Brierwood Coop](http://brierwood.coop) | Mobile apps | Ottawa, Ontario, Canada | |
 [Feel Train](https://feeltrain.com/) |  | Portland, OR, USA | *"Feel Train will never consist of more than 8 people."*
 [Gaia Host Collective](http://gaiahost.coop) | Hosting | Greenfield, MA, USA |
 [Quilted](http://quilted.coop) | consulting, graphic design, web development | Berkeley, California, USA | *"Quilted is a worker-owned, cooperatively-managed company stitching together technology and social change."*

--- a/README.md
+++ b/README.md
@@ -55,7 +55,6 @@ Coop | Business Areas | Region/Country | Notes
 ---- | -------------- | -------------- | -----
 [Agaric](http://agaric.coop/) | Web development, tech consulting | USA / Nicaragua / Germany | Worker-owned collective building online since 2006, lately contributing to the [Drutopia](https://drutopia.org/) platform for grassroots groups.
 [Baseline](https://baseline.quebec/en/) | AI consulting | Quebec City, Quebec, Canada | Baseline is the outcome of a collective will to share resources, to give ourselves greater visibility and to pool common expenses and risks, while respecting our individual needs. |
-[Brierwood Coop](http://brierwood.coop) | Mobile apps | Ottawa, Ontario, Canada | |
 [CanTrust Hosting Co-op](https://cantrusthosting.coop/) | Hosting, personal cloud, and IT consulting | Vancouver, BC, Canada | Started in 2009, provides community-focused web hosting at affordable prices to clients, many of whom are like-minded social economy organizations. |
 [Caravan Web Worker Cooperative](https://caravan.coop) | Web design, Software development (Python) | Montreal and Quebec City, Canada | |
 [Catalyst Cooperative](https://catalyst.coop) | Open data engineering / analysis for energy & climate policy | Distributed / Remote, North America | |


### PR DESCRIPTION
The domain is for sale. The coop site appears to have been down for a [number of years](https://web.archive.org/web/20240000000000*/http://brierwood.coop/)