### PR TITLE
Remove Resonate entry

### DIFF
--- a/DEFUNCT.md
+++ b/DEFUNCT.md
@@ -18,3 +18,4 @@ Coop | Business Areas | Region/Country | Notes
 Coop | Business Areas | Region/Country | Notes
 ---- | -------------- | -------------- | -----
 [Rabotnik](https://www.rabotnik.coop/) |  graphic design, web-development, video production and animation, campaign and concept development | Denmark | |
+[Resonate](http://resonate.is) | Music Streaming  | Berlin, Germany / Dublin, Ireland| A multistakeholder platform co-operative - with contributors (workers, contractors, volunteers) represented with a 20% ownership stake.

--- a/README.md
+++ b/README.md
@@ -208,7 +208,6 @@ Coop | Business Areas | Region/Country | Notes
 [Probesys](https://www.probesys.com) | Web development, System Administration, Hosting | Grenoble, France | We provide Open Source development and infrastructure expertise |
 [Rapid Assessment Delivery Cooperative (RAD COP)](https://radcop.online/) | Penetration and Social Engineering Testing, Compliance and Methodology, other kinds of security analysis and engineering | Krasnogorsk, Russia | We deal with almost all popular cybersecurity domains: from implementing DevSecOps processes to compliance audits according to information security standards, from setting up technical information protection tools to writing regulatory documents. |
 [Reinblau](https://reinblau.coop/) | Web development | Berlin, Germany | |
-[Resonate](http://resonate.is) | Music Streaming  | Berlin, Germany / Dublin, Ireland| A multistakeholder platform co-operative - with contributors (workers, contractors, volunteers) represented with a 20% ownership stake.
 [Robur](https://robur.coop) | Software Development | Berlin, Germany | |
 [roko.li](https://roko.li) | Software Development, Hosting | Potsdam/ Rostock, Germany | |
 [Sange](http://www.sange.fi/) | Hosting | Helsinki, Finland | |


### PR DESCRIPTION
"The Resonate co-op has been officially dissolved."

http://resonate.is redirects to https://resonate.coop/ which I noticed today has shut down:
> The Resonate co-op has been officially dissolved. A few former board members remain to close out the financials, including potential artist payments.

See also: [github.com/resonatecoop/website PR from 12 Feb 2026](https://github.com/resonatecoop/website/pull/103) announcing the shutdown.