### PR TITLE
Remove Vermont Computing Cooperative

### DIFF
--- a/DEFUNCT.md
+++ b/DEFUNCT.md
@@ -12,6 +12,7 @@ Coop | Business Areas | Region/Country | Notes
 [Quilted](http://quilted.coop) | consulting, graphic design, web development | Berkeley, California, USA | *"Quilted is a worker-owned, cooperatively-managed company stitching together technology and social change."*
 [RadicalDesign](http://radicaldesigns.org) | Web development  | Oakland, CA, USA | Focusing on non-profit and grassroots social change organizations
 [Seattle Developers Cooperative](https://seattledevelopers.coop/) | Web development, React, Node.js | Seattle, Washington, USA | Founded 2018; Working on P2P projects in JavaScript
+[Vermont Computing Cooperative](https://vtcc.coop/) | Hardware, Websites, E-mail, Hosting | Vermont, US | |
 
 ### Europe
 

--- a/README.md
+++ b/README.md
@@ -97,7 +97,6 @@ Coop | Business Areas | Region/Country | Notes
 [the Tech Support Cooperative](https://site.techsupport.coop/) | POS software, open-source web development, consulting | US + CAN | Maintainers of the [CORE-POS / IS4C](https://github.com/CORE-POS/IS4C) software project |
 [Tierra Común](https://tierracomun.org/) | digital security, sysadmin, web design | Mexico | |
 [Ultri Co-op](https://ultri.com/) | Business Management Software | Worldwide | A multi-stakeholder co-op, where developers and SaaS users are co-owners of the business.|
-[Vermont Computing Cooperative](https://vtcc.coop/) | Hardware, Websites, E-mail, Hosting | Vermont, US | |
 [Vulk Coop](http://vulk.coop) | Design, Development | Austin, TX, USA | Worker-owned, Founded 2013, Organizers of [Austin Software Co-operatives Meetup](https://www.meetup.com/de-DE/Austin-Software-Co-operatives/)|
 [Weaver Digital Design + Storytelling Co-op](https://weaver.coop/) | Full stack website design and development. | Unceded territories of the Lekwungen speaking peoples in so-called BC, Canada | We create outstanding, user-friendly digital experiences that help businesses and organizations connect with their audiences, innovate and grow. |
 [Willow Bark](https://willowbark.org) | Design, Development, sysadmin, security | Remote, international |


### PR DESCRIPTION
The linked website now says

> Vermont Computing Cooperative is now: vermont.computer

There is no mention of being a cooperative in the new website.