### PR TITLE
Add workerowned.info to Tools section

### DIFF
--- a/README.md
+++ b/README.md
@@ -373,6 +373,7 @@ Coop | Business Areas | Notes
 
 * [Cobudget](https://cobudget.com) - Crowdsource and fund projects within an organization. Developed and used by Enspiral.
 * [Loomio](https://www.loomio.org) - Online decision-making
+* [workerowned.info](https://workerowned.info) - Searchable marketplace of 190,000+ products from 175+ worker and employee owned companies. Search and buy directly from co-op stores.
 
 <a name="products"></a>
 


### PR DESCRIPTION
workerowned.info is a searchable marketplace of 190,000+ products from 175+ worker and employee owned companies. You search for a product, see which co-ops sell it, and click through to buy from their store directly. No middleman, no commissions, no tracking.

It covers consumer products -- coffee, chocolate, books, records, soap, shoes, sporting goods, home goods, bikes, and more. There is also a location directory of 115+ worker-owned coffee shops, restaurants, and bars across the US.

I built it because worker-owned companies make great stuff but they are hard to discover. The goal is to make them as easy to find as anything on Amazon.

It is a volunteer project -- I do not make anything from it. It was featured on [Hacker News](https://news.ycombinator.com/item?id=48752905) (389 points), [Pluralistic](https://pluralistic.net/2026/07/28/), and [GEO](https://geo.coop/articles/new-directory-worker-co-ops-products).

One thing I have noticed building it: there is a big gap in tech/electronics from worker-owned companies. If anyone here knows co-ops making or selling tech products, I would love to add them.